### PR TITLE
fix: enable gestures for drawer toggle

### DIFF
--- a/template/android/app/src/main/java/com/dvhbapp/MainActivity.java
+++ b/template/android/app/src/main/java/com/dvhbapp/MainActivity.java
@@ -1,6 +1,9 @@
 package com.dvhbapp;
 
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 import org.devio.rn.splashscreen.SplashScreen;
 import android.os.Bundle;
 
@@ -18,5 +21,15 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "DvhbApp";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegate(this, getMainComponentName()) {
+      @Override
+      protected ReactRootView createRootView() {
+        return new RNGestureHandlerEnabledRootView(MainActivity.this);
+      }
+    };
   }
 }

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { createAppContainer, NavigationContainerComponent } from 'react-navigation';
+import 'react-native-gesture-handler';
 
 import { navigationService } from './services/navigation';
 import { navigationWithDrawer } from './navigation';


### PR DESCRIPTION
React Navigation requires additional configuration for gestures to work on Android, otherwise swipe from edge to open drawer and backdrop tap to close drawer are not working.

https://reactnavigation.org/docs/4.x/getting-started#install-into-an-existing-project