### PR TITLE
fix: add missing dotenv gradle import for android

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 import com.android.build.OutputFile
 


### PR DESCRIPTION
https://github.com/luggit/react-native-config#extra-step-for-android